### PR TITLE
Fix unstable test

### DIFF
--- a/t/20_test_def_and_undef_or.t
+++ b/t/20_test_def_and_undef_or.t
@@ -81,7 +81,7 @@ test_contract(
 	      [ b => 1, a => 4 ], 5, undef,
 	      [ a => undef, b => 4 ], 4, undef,
 	      [ a => undef, b => undef ], undef, "input argument of Bob::add with key 'b' fails its constraint",
-	      [ a => 'abc', b => undef ], undef, "input argument of Bob::add with key 'a' fails its constraint",
+	      [ a => 'abc', b => 4 ], undef, "input argument of Bob::add with key 'a' fails its constraint",
 	      );
 
 


### PR DESCRIPTION
See https://rt.cpan.org/Public/Bug/Display.html?id=109261

This test depended on the order of elements in a hash. Since Perl 5.17.6, this
order is randomized, resulting in the test sometimes succeeding and sometimes
failing in recent Perl versions.

This is solved by adjusting the test so that there is only one violation of the
contract.